### PR TITLE
Add Vitest setup and HeroSection test

### DIFF
--- a/client/src/components/__tests__/HeroSection.test.tsx
+++ b/client/src/components/__tests__/HeroSection.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { HeroSection } from '../HeroSection';
+
+describe('HeroSection', () => {
+  it('renders heading and button', () => {
+    render(<HeroSection />);
+    expect(
+      screen.getByRole('heading', { name: /assessoria esportiva/i })
+    ).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /começar agora/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('scrolls to section when button clicked', () => {
+    const target = document.createElement('div');
+    target.id = 'planos';
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+
+    render(<HeroSection />);
+    const button = screen.getByRole('button', { name: /começar agora/i });
+    fireEvent.click(button);
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, ...props }, ref) => (
+    <button ref={ref} {...props}>
+      {children}
+    </button>
+  )
+);
+Button.displayName = "Button";

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "vitest",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
@@ -110,7 +111,11 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.5.3",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.5",
+    "jsdom": "^22.1.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "client/src/**/*.test.ts", "client/src/**/*.test.tsx"],
+  "exclude": ["node_modules", "build", "dist"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
@@ -14,7 +14,7 @@
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "vitest"],
     "paths": {
       "@/*": ["./client/src/*"],
       "@shared/*": ["./shared/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
@@ -33,5 +33,9 @@ export default defineConfig({
       strict: true,
       deny: ["**/.*"],
     },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
   },
 });


### PR DESCRIPTION
## Summary
- install Vitest and testing libraries
- configure Vitest in vite.config
- include test files in tsconfig and add `npm test` script
- provide minimal Button component
- add example test for HeroSection

## Testing
- `npm run test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f2ae59988328b4dd4033b5ed449b